### PR TITLE
delegate angular peer dependencies

### DIFF
--- a/projects/rating/package.json
+++ b/projects/rating/package.json
@@ -2,8 +2,8 @@
   "name": "ng-starrating",
   "version": "1.0.20",
   "peerDependencies": {
-    "@angular/common": "^9.0.1",
-    "@angular/core": "^9.0.1"
+    "@angular/common": "*",
+    "@angular/core": "*",
   },
   "dependencies": {
     "tslib": "^2.0.0"


### PR DESCRIPTION
delegate peer dependencies angular version to parent project to avoid disuse.
for example :
 Package "ng-starrating" has an incompatible peer dependency to "@angular/common" (requires "^9.0.1" (extended), would install "11.0.5").